### PR TITLE
feat: specify an exact desired version

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ micrate dbversion # at any time you can find out the current version of the da
 20160524162446
 ```
 
-If you ever need to roll back the last migration, you can do so by executing `micrate down`. There's also `micrate redo` which rolls back the last migration and applies it again. Last but not least: use `micrate status` to find out the state of each migration:
+If you ever need to roll back the last migration, you can do so by executing `micrate down`. There's also `micrate redo` which rolls back the last migration and applies it again. If you want to migrate to a specific version, execute `micrate to -v 20160524162446` or even `micrate 20160524162446` (for example). Last but not least: use `micrate status` to find out the state of each migration:
 
 ```
 $ micrate status

--- a/shard.yml
+++ b/shard.yml
@@ -1,8 +1,9 @@
 name: micrate
-version: 0.3.0
+version: 0.3.1
 
 authors:
   - Juan Edi <jedi11235@gmail.com>
+  - Vlad Faust <mail@vladfaust.com>
 
 dependencies:
   db:

--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -15,6 +15,12 @@ module Micrate
     end
   end
 
+  def self.exact(db, target, migrations_path = DEFAULT_MIGRATIONS_PATH, migrations_table_suffix = "")
+    all_migrations = migrations_by_version(migrations_path)
+    current = dbversion(db, migrations_table_suffix)
+    migrate(all_migrations, current, target, db, migrations_table_suffix)
+  end
+
   def self.up(db, migrations_path = DEFAULT_MIGRATIONS_PATH, migrations_table_suffix = "")
     all_migrations = migrations_by_version(migrations_path)
 

--- a/src/micrate/version.cr
+++ b/src/micrate/version.cr
@@ -1,3 +1,3 @@
 module Micrate
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
Fixes #21

Adds `Micrate.exact`, `$ micrate to -v <version>` and `$ micrate <version>`