### PR TITLE
Specify that you have to require database adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ you can create a simple script like the following (we'll call it bin/micrate in 
 
 ```crystal
 #! /usr/bin/env crystal
+
+# Require your database's adapter
+# require "pg"
+# require "mysql"
+# require "sqlite3"
+
 require "micrate"
 
 Micrate::Cli.run


### PR DESCRIPTION
Hello! If a user creates a `micrate` executable and runs it, as specified in README.md, he/she is going to get the following error:

```bash
in lib/micrate/src/micrate.cr:16: instantiating 'Micrate::DB:Module#get_versions_last_first_order(DB::Database)'

      rows = DB.get_versions_last_first_order(db)    
                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~        

in lib/micrate/src/micrate/db.cr:30: instantiating 'DB::Database#query_all(String)'                       

      db.query_all "SELECT version_id, is_applied from micrate_db_version ORDER BY id DESC", as: {Int64, Bool}
         ^~~~~~~~~        

in lib/db/src/db/query_methods.cr:215: can't infer block return type, try to cast the block body with `as`. See: https://github.com/crystal-lang/crystal/wiki/Compiler-error-messages#cant-infer-block-return-type

      query_all(query, *args) do |rs|    
```

To make it work, is mandatory to require the database adapter. This PR adds this information to Readme