### PR TITLE
Fixes micrate timestamp collisions

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,6 +4,7 @@ version: 0.3.1
 authors:
   - Juan Edi <jedi11235@gmail.com>
   - Vlad Faust <mail@vladfaust.com>
+  - Amber Team <amberframework.org>
 
 dependencies:
   db:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: micrate
-version: 0.4.0
+version: 0.3.3
 
 authors:
   - Juan Edi <jedi11235@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: micrate
-version: 0.3.3
+version: 0.4.0
 
 authors:
   - Juan Edi <jedi11235@gmail.com>

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: micrate
-version: 0.3.1
+version: 0.4.0
 
 authors:
   - Juan Edi <jedi11235@gmail.com>

--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -62,7 +62,7 @@ module Micrate
   end
 
   def self.create(name, time, migrations_path = DEFAULT_MIGRATIONS_PATH)
-    timestamp = time.to_s("%Y%m%d%H%M%S")
+    timestamp = time.to_s("%Y%m%d%H%M%S%L")
     filename = File.join(migrations_path, "#{timestamp}_#{name}.sql")
 
     migration_template = "\

--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -144,13 +144,13 @@ module Micrate
   end
 
   private def self.fix_timestamp_collisions(migrations)
-    migrations.map do |migration|
+    migrations.map_with_index do |migration, index|
       count = migrations.count { |this_migration| this_migration.version == migration.version }
       pp! count
       if count > 1
         collision_path = File.join(Micrate.migrations_dir, migration.name)
         new_name = migration.name.split("_")
-        new_version = new_name.shift.to_i64 + 1
+        new_version = new_name.shift.to_i64 + index
         new_path = File.join(Micrate.migrations_dir, "#{new_version}_" + new_name.join("_"))
         File.rename(collision_path, new_path)
         migration.version = new_version

--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -147,7 +147,8 @@ module Micrate
     Dir.entries(migrations_path)
        .select { |name| File.file? File.join(migrations_path, name) }
        .select { |name| /^\d+_.+\.sql$/ =~ name }
-       .map { |name| Migration.from_file(migrations_path, name) }
+       .sort
+       .map_with_index { |name, index| Migration.from_file(name, index) }
        .index_by { |migration| migration.version }
   end
 

--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -143,13 +143,31 @@ module Micrate
     end
   end
 
-  private def self.migrations_by_version(migrations_path)
-    Dir.entries(migrations_path)
-       .select { |name| File.file? File.join(migrations_path, name) }
-       .select { |name| /^\d+_.+\.sql$/ =~ name }
-       .sort
-       .map_with_index { |name, index| Migration.from_file(migrations_path, name, index) }
-       .index_by { |migration| migration.index }
+  private def self.fix_timestamp_collisions(migrations)
+    migrations.map do |migration|
+      count = migrations.count { |this_migration| this_migration.version == migration.version }
+      pp! count
+      if count > 1
+        collision_path = File.join(Micrate.migrations_dir, migration.name)
+        new_name = migration.name.split("_")
+        new_version = new_name.shift.to_i64 + 1
+        new_path = File.join(Micrate.migrations_dir, "#{new_version}_" + new_name.join("_"))
+        File.rename(collision_path, new_path)
+        migration.version = new_version
+        migration
+      else
+        migration
+      end
+    end
+  end
+
+  private def self.migrations_by_version
+    migrations = Dir.entries(migrations_dir)
+                    .select { |name| File.file? File.join("db/migrations", name) }
+                    .select { |name| /^\d+_.+\.sql$/ =~ name }
+                    .map { |name| Migration.from_file(name) }
+    migrations_without_collisions = fix_timestamp_collisions(migrations)
+    migrations_without_collisions.index_by { |migration| migration.version }
   end
 
   def self.migration_plan(status : Hash(Migration, Time?), current : Int, target : Int, direction)

--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -148,7 +148,7 @@ module Micrate
        .select { |name| File.file? File.join(migrations_path, name) }
        .select { |name| /^\d+_.+\.sql$/ =~ name }
        .sort
-       .map_with_index { |name, index| Migration.from_file(name, index) }
+       .map_with_index { |name, index| Migration.from_file(migrations_path, name, index) }
        .index_by { |migration| migration.version }
   end
 

--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -149,7 +149,7 @@ module Micrate
        .select { |name| /^\d+_.+\.sql$/ =~ name }
        .sort
        .map_with_index { |name, index| Migration.from_file(migrations_path, name, index) }
-       .index_by { |migration| migration.version }
+       .index_by { |migration| migration.index }
   end
 
   def self.migration_plan(status : Hash(Migration, Time?), current : Int, target : Int, direction)

--- a/src/micrate/migration.cr
+++ b/src/micrate/migration.cr
@@ -5,8 +5,9 @@ module Micrate
     getter version
     getter name
     getter source
+    getter index
 
-    def initialize(@version : Int64, @name : String, @source : String)
+    def initialize(@version : Int64, @name : String, @source : String, @index = 0)
     end
 
     # Algorithm ported from Goose

--- a/src/micrate/migration.cr
+++ b/src/micrate/migration.cr
@@ -69,8 +69,8 @@ module Micrate
 
     def self.from_file(directory, file_name, index = 0)
       full_path = File.join(directory, file_name)
-      version = file_name.split("_")[0].to_i64 + index
-      new(version, file_name, File.read(full_path))
+      version = file_name.split("_")[0].to_i64
+      new(version, file_name, File.read(full_path), index)
     end
 
     def self.from_version(directory, version)

--- a/src/micrate/migration.cr
+++ b/src/micrate/migration.cr
@@ -67,8 +67,8 @@ module Micrate
       s.split("--")[0].strip.ends_with? ";"
     end
 
-    def self.from_file(file_name, index = 0)
-      full_path = File.join(Micrate.migrations_dir, file_name)
+    def self.from_file(directory, file_name, index = 0)
+      full_path = File.join(directory, file_name)
       version = file_name.split("_")[0].to_i64 + index
       new(version, file_name, File.read(full_path))
     end

--- a/src/micrate/migration.cr
+++ b/src/micrate/migration.cr
@@ -67,9 +67,9 @@ module Micrate
       s.split("--")[0].strip.ends_with? ";"
     end
 
-    def self.from_file(directory, file_name)
-      full_path = File.join(directory, file_name)
-      version = file_name.split("_")[0].to_i64
+    def self.from_file(file_name, index = 0)
+      full_path = File.join(Micrate.migrations_dir, file_name)
+      version = file_name.split("_")[0].to_i64 + index
       new(version, file_name, File.read(full_path))
     end
 

--- a/src/micrate/migration.cr
+++ b/src/micrate/migration.cr
@@ -2,12 +2,11 @@ module Micrate
   class Migration
     SQL_CMD_PREFIX = "-- +micrate "
 
-    getter version
+    property version
     getter name
     getter source
-    getter index
 
-    def initialize(@version : Int64, @name : String, @source : String, @index = 0)
+    def initialize(@version : Int64, @name : String, @source : String)
     end
 
     # Algorithm ported from Goose
@@ -68,10 +67,10 @@ module Micrate
       s.split("--")[0].strip.ends_with? ";"
     end
 
-    def self.from_file(directory, file_name, index = 0)
+    def self.from_file(directory, file_name)
       full_path = File.join(directory, file_name)
       version = file_name.split("_")[0].to_i64
-      new(version, file_name, File.read(full_path), index)
+      new(version, file_name, File.read(full_path))
     end
 
     def self.from_version(directory, version)

--- a/src/micrate/version.cr
+++ b/src/micrate/version.cr
@@ -1,3 +1,3 @@
 module Micrate
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
This PR does:

- Bugfix to group by index without missing versions with same timestamp.
- Add Amber Team to shard.yml
- Add version v0.4.0 (still requires to release tag `v0.4.0` because **`shards` doesn't detect new version without tag**

This Fix is already published on `v0.3.1`, based on `v0.3.0` because micrate master has some breaking changes.

Please see:  https://github.com/amberframework/micrate/releases/tag/v0.3.1

Fixes: #31