### PR TITLE
Sort Migration Status

### DIFF
--- a/src/micrate/cli.cr
+++ b/src/micrate/cli.cr
@@ -31,7 +31,7 @@ module Micrate
       DB.connect do |db|
         puts "Applied At                  Migration"
         puts "======================================="
-        Micrate.migration_status(db, migrations_path, migrations_table_suffix).each do |migration, migrated_at|
+        Micrate.migration_status(db, migrations_path, migrations_table_suffix).sort_by { |migration, migrated_at| migrated_at }.each do |migration, migrated_at|
           ts = migrated_at.nil? ? "Pending" : migrated_at.to_s
           puts "%-24s -- %s\n" % [ts, migration.name]
         end


### PR DESCRIPTION
When listing the migrations run with `amber db status` the list of
migrations needs to be ordered by the time this migrations were applied
so the developer can have a clearer, more defragmented idea of how the
schema of the application has changed over time.

To achieve this, this change

* makes sure the list of migration is sorted by `migrated_at` before
printing

Resolves #35