### PR TITLE
Update to Crystal 0.33.0

### DIFF
--- a/src/micrate/db/sqlite3.cr
+++ b/src/micrate/db/sqlite3.cr
@@ -19,7 +19,7 @@ module Micrate::DB
     end
 
     def query_record_migration(migration, is_applied, db)
-      db.exec("INSERT INTO micrate_db_version (version_id, is_applied, tstamp) VALUES (?, ?, ?);", migration.version, is_applied, Time.now)
+      db.exec("INSERT INTO micrate_db_version (version_id, is_applied, tstamp) VALUES (?, ?, ?);", migration.version, is_applied, Time.local)
     end
   end
 end


### PR DESCRIPTION
`Time.now` was deprecated in 0.28.0 and will be removed in 0.33.0

The other drivers seem to use the local time of the server for the migration AFAIK.