### PR TITLE
Implement unconditional transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ To use the Crystal API, add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   micrate:
-    github: juanedi/micrate
+    github: amberframework/micrate
 ```
 
 This allows you to programatically use micrate's features. You'll see the `Micrate` module has an equivalent for every CLI command. If you need to use micrate's CLI without installing the tool (which could be convenient in a CI environment), you can write a runner script as follows:
@@ -114,7 +114,7 @@ Micrate::Cli.run
 
 ## Contributing
 
-1. Fork it ( https://github.com/juanedi/micrate/fork )
+1. Fork it ( https://github.com/amberframework/micrate/fork )
 2. Create your feature branch (git checkout -b my-new-feature)
 3. Commit your changes (git commit -am 'Add some feature')
 4. Push to the branch (git push origin my-new-feature)

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: micrate
-version: 0.6.0
+version: 0.6.1
 crystal: 0.32.1
 
 authors:

--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -107,11 +107,11 @@ module Micrate
       begin
 
         # Wrap migration in a transaction
-        DB.exec("BEGIN;\n")
+        DB.exec("BEGIN;\n", db)
         migration.statements(direction).each do |stmt|
           DB.exec(stmt, db)
         end
-        DB.exec("\nCOMMIT;")
+        DB.exec("\nCOMMIT;", db)
 
         DB.record_migration(migration, direction, db)
 


### PR DESCRIPTION
In addition to minor cleanups like updating README references, this merge request makes all migrations run in a transaction by default, by wrapping all of the statements in each migration with a `Begin` and `Commit` block.

I've tested this on a Postgres setup, and the documentation for MySQL and SQLite both state support for these commands.

Admittedly, I'm not entirely sure what undesired effects there will be for people already writing transactions in their migration files. Fortunately, it seems like nested transactions are generally supported.

Even then, I imagine that most use cases aren't effected, and only serve to benefit from being automatically wrapped.

Fixes #11 .