### PR TITLE
Update for Crystal v0.34.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,4 +12,4 @@ maintainers:
 dependencies:
   db:
     github: crystal-lang/crystal-db
-    version: ~> 0.8.0
+    version: ~> 0.9.0

--- a/src/micrate/migration.cr
+++ b/src/micrate/migration.cr
@@ -75,8 +75,8 @@ module Micrate
 
     def self.from_version(version)
       file_name = Dir.entries(Micrate.migrations_dir)
-                     .find { |name| name.starts_with? version.to_s  }
-                     .not_nil!
+        .find { |name| name.starts_with? version.to_s }
+        .not_nil!
       self.from_file(file_name)
     end
   end

--- a/src/micrate/migration.cr
+++ b/src/micrate/migration.cr
@@ -46,6 +46,8 @@ module Micrate
               statement_ended = ignore_semicolons == true
               ignore_semicolons = false
             end
+          else
+            # TODO? invalid command
           end
         end
 


### PR DESCRIPTION
This is required to compile in 0.34.0 without warnings.

This changes and crystal-db are still compatible with older crystal versions

crystal-pg compatible version should be released shortly.