### PR TITLE
fix: Changing "db/migrations" to migrations_dir

### DIFF
--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -158,7 +158,7 @@ module Micrate
 
   private def self.migrations_by_version
     Dir.entries(migrations_dir)
-      .select { |name| File.file? File.join("db/migrations", name) }
+      .select { |name| File.file? File.join(migrations_dir, name) }
       .select { |name| /^\d+.+\.sql$/ =~ name }
       .map { |name| Migration.from_file(name) }
       .index_by { |migration| migration.version }


### PR DESCRIPTION
Solve no migration found when db_dir as been overloaded