### PR TITLE
Update shard.yml to match 0.11.0 tag

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: micrate
-version: 0.10.0
+version: 0.11.0
 crystal: 1.0.0
 
 authors:


### PR DESCRIPTION
The version in `shard.yml` does not match the current release tag.

I'm not sure about it but does the tag on a commit should directly match the configuration file or is it good to have them separated on two commits ? Otherwise I will update the PR for the `0.11.1` version if we need to bump a new release to fix the issue.