### PR TITLE
Fix: broken installation with pg

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: micrate
-version: 0.10.0
-crystal: 1.0.0
+version: 0.11.0
+crystal: ">= 0.36.1, < 2.0.0"
 
 authors:
   - Juan Edi <jedi11235@gmail.com>
@@ -14,15 +14,6 @@ targets:
     main: src/micrate-bin.cr
 
 dependencies:
-  pg:
-    github: will/crystal-pg
-    version: ~> 0.23.1
-  mysql:
-    github: crystal-lang/crystal-mysql
-    version: ~> 0.13.0
-  sqlite3:
-    github: crystal-lang/crystal-sqlite3
-    version: ~> 0.18.0
   db:
     github: crystal-lang/crystal-db
     version: ~> 0.10.0
@@ -31,3 +22,12 @@ development_dependencies:
   spectator:
     gitlab: arctic-fox/spectator
     branch: master
+  pg:
+    github: will/crystal-pg
+    version: ~> 0.24.0
+  mysql:
+    github: crystal-lang/crystal-mysql
+    version: ~> 0.13.0
+  sqlite3:
+    github: crystal-lang/crystal-sqlite3
+    version: ~> 0.18.0

--- a/src/micrate/cli.cr
+++ b/src/micrate/cli.cr
@@ -1,9 +1,5 @@
 require "log"
 
-require "pg"
-require "mysql"
-require "sqlite3"
-
 module Micrate
   module Cli
     Log = ::Log.for(self)


### PR DESCRIPTION
Fixes #77 and allows to install pg 0.24 (and any forthcoming version) alongside micrate's main branch, which is compatible with Crystal 0.36+. Micrate was fixed to pg 0.23 which didn't work with 0.36+

- Don't depend on neither of the pg, mysql or sqlite3 shards. Only use them as development dependencies.
- Fixes the crystal version as `>= 0.36.1, < 2.0.0` which allows using the 0.36 version (which is compatible) as well as any upcoming 1.0 version without breaking changes.
- Upgrades the version reported in `shard.yml` as 0.11.0.