### PR TITLE
Fix use of transactions to apply migrations

### DIFF
--- a/src/micrate.cr
+++ b/src/micrate.cr
@@ -115,10 +115,10 @@ module Micrate
       # Wrap migration in a transaction
       db.transaction do |tx|
         migration.statements(direction).each do |stmt|
-          db.exec(stmt)
+          tx.connection.exec(stmt)
         end
 
-        DB.record_migration(migration, direction, db)
+        DB.record_migration(migration, direction, tx.connection)
 
         tx.commit
         Log.info { "OK   #{migration.name}" }


### PR DESCRIPTION
This patch fixes an issue that has apparently existed for a very long time: application of migrations in a transaction has not been working as intended!

Currently, if you apply a migration like the following:

```sql
-- +micrate Up
CREATE TABLE foo (x int);
invalid_sql;
-- +micrate Down
DROP TABLE foo;
```

This will:

1. Create table `foo`
2. Crash on parsing `invalid_sql`

When this happens, the database will be left in a partially migrated state, with `foo` created and the migration marked as applied, essentially "bricking" micrate until you manually resolve it.

- The migration will not be marked as applied
- If you try to run `up` again, it will complain `foo` already exists, so you need to add `IF NOT EXISTS` or manually `DROP TABLE foo;`.
- Hopefully there are no more errors, or you'll have to do it again!

The reason this happens was just because of the misuse of the transaction API. Opening a tx with `db.transaction` checks out a connection from the pool, and issues `BEGIN` for you. From there, you must issue queries against `tx.connection` - where the tx is taking place - in order for them to be applied.

Instead, `db` is used again, which instead pull *another* connection from the DB pool; meaning the tx does not get *any* of the migration statements.

With this fix, failed migrations will be fully rolled back as intended, allowing you to make fixes & run `up` again without issue.