### PR TITLE
Bump version to 0.15.1 on shards.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: micrate
-version: 0.14.0
+version: 0.15.1
 crystal: ">= 0.36.1, < 2.0.0"
 
 authors:


### PR DESCRIPTION
This is to avoid the warning:

```
Shard "micrate" version (0.14.0) doesn't match tag version (0.15.0)
```

So a release must be done after this get merged to fix the issue.